### PR TITLE
Moar assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,23 @@ version = "0.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = []
+toml-serde = ["toml", "serde"]
+json-serde = ["serde_json", "serde"]
+
 [dependencies]
 image = "0.24.5"
 mime = "0.3.16"
 reqwest = { version = "0.11.13", features = ["json"] }
 thiserror = "1.0.37"
-toml = "0.5.9"
 url = "2.3.1"
 miette = "5.6.0"
+
+toml = { version = "0.5.9", optional = true }
+serde_json = { version = "1.0.95", optional = true }
+serde = { version = "1.0.159", optional = true, features = ["derive"] }
+camino = "1.1.4"
 
 [dev-dependencies]
 assert_fs = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -227,4 +227,57 @@ pub enum AxoassetError {
         /// The origin path of the asset, used as an identifier
         origin_path: String,
     },
+    /// This error indicates we ran `std::env::current_dir` and somehow got an error.
+    #[error("Failed to get the current working directory")]
+    CurrentDir {
+        /// Details of the error
+        #[source]
+        details: std::io::Error,
+    },
+    /// This error indicates we failed to convert a Path/PathBuf to a Utf8Path/Utf8PathBuf
+    #[error("This path isn't utf8: {path:?}")]
+    Utf8Path {
+        /// The problematic path
+        path: std::path::PathBuf,
+    },
+    #[error("Failed to find {desired_filename} in an ancestor of {start_dir}")]
+    /// This error indicates we failed to find the desired file in an ancestor of the search dir.
+    SearchFailed {
+        /// The dir we started the search in
+        start_dir: camino::Utf8PathBuf,
+        /// The filename we were searching for
+        desired_filename: String,
+    },
+
+    /// This error indicates we tried to deserialize some JSON with serde_json
+    /// but failed.
+    #[cfg(feature = "json-serde")]
+    #[error("failed to parse JSON")]
+    Json {
+        /// The SourceFile we were try to parse
+        #[source_code]
+        source: crate::SourceFile,
+        /// The range the error was found on
+        #[label]
+        span: miette::SourceSpan,
+        /// Details of the error
+        #[source]
+        details: serde_json::Error,
+    },
+
+    /// This error indicates we tried to deserialize some TOML with toml-rs (serde)
+    /// but failed.
+    #[cfg(feature = "toml-serde")]
+    #[error("failed to parse TOML")]
+    Toml {
+        /// The SourceFile we were try to parse
+        #[source_code]
+        source: crate::SourceFile,
+        /// The range the error was found on
+        #[label]
+        span: miette::SourceSpan,
+        /// Details of the error
+        #[source]
+        details: toml::de::Error,
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,15 @@ use std::path::PathBuf;
 pub(crate) mod error;
 pub(crate) mod local;
 pub(crate) mod remote;
+pub(crate) mod source;
+pub(crate) mod spanned;
 
 pub use error::AxoassetError;
 use error::Result;
 pub use local::LocalAsset;
 pub use remote::RemoteAsset;
+pub use source::SourceFile;
+pub use spanned::Spanned;
 
 /// An asset can either be a local asset, which is designated by a path on the
 /// local file system, or a remote asset, which is designated by an http or

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,175 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use camino::Utf8Path;
+use miette::{MietteSpanContents, SourceCode, SourceSpan};
+
+use crate::{error::*, Asset, LocalAsset, RemoteAsset};
+
+/// The inner contents of a [`SourceFile`][].
+#[derive(Eq, PartialEq)]
+struct SourceFileInner {
+    /// "Name" of the file (this can be a path if you want)
+    name: String,
+    /// Contents of the file
+    source: String,
+}
+
+/// A file's contents along with its display name
+///
+/// This is used for reporting rustc-style diagnostics where we show
+/// where in the file we found a problem. It contains an Arc so that
+/// it's ~free for everything to pass/copy these around and produce
+/// better diagnostics.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SourceFile {
+    /// The actual impl
+    inner: Arc<SourceFileInner>,
+}
+
+impl SourceFile {
+    /// Create an empty SourceFile with the given name
+    pub fn new_empty(name: &str) -> Self {
+        Self::new(name, String::new())
+    }
+    /// Create a new source file with the given name and contents.
+    pub fn new(name: &str, source: String) -> Self {
+        SourceFile {
+            inner: Arc::new(SourceFileInner {
+                name: name.to_owned(),
+                source,
+            }),
+        }
+    }
+
+    /// SourceFile equivalent of [`RemoteAsset::load`][]
+    pub async fn load_remote(origin_path: &str) -> Result<SourceFile> {
+        let source = RemoteAsset::load_string(origin_path).await?;
+        Ok(SourceFile {
+            inner: Arc::new(SourceFileInner {
+                name: origin_path.to_owned(),
+                source,
+            }),
+        })
+    }
+
+    /// SourceFile equivalent of [`LocalAsset::load`][]
+    pub fn load_local<'a>(origin_path: impl Into<&'a Utf8Path>) -> Result<SourceFile> {
+        let origin_path = origin_path.into();
+        let source = LocalAsset::load_string(origin_path.as_str())?;
+        Ok(SourceFile {
+            inner: Arc::new(SourceFileInner {
+                name: origin_path.to_string(),
+                source,
+            }),
+        })
+    }
+
+    /// SourceFile equivalent of [`Asset::load`][]
+    pub async fn load(origin_path: &str) -> Result<SourceFile> {
+        let source = Asset::load_string(origin_path).await?;
+        Ok(SourceFile {
+            inner: Arc::new(SourceFileInner {
+                name: origin_path.to_owned(),
+                source,
+            }),
+        })
+    }
+
+    /// Try to deserialize the contents of the SourceFile as json
+    #[cfg(feature = "json-serde")]
+    pub fn deserialize_json<'a, T: serde::Deserialize<'a>>(&'a self) -> Result<T> {
+        let json = serde_json::from_str(self.source()).map_err(|details| {
+            let span = self
+                .span_for_line_col(details.line(), details.column())
+                .unwrap_or((0..0).into());
+            AxoassetError::Json {
+                source: self.clone(),
+                span,
+                details,
+            }
+        })?;
+        Ok(json)
+    }
+
+    /// Try to deserialize the contents of the SourceFile as toml
+    #[cfg(feature = "toml-serde")]
+    pub fn deserialize_toml<'a, T: serde::Deserialize<'a>>(&'a self) -> Result<T> {
+        let toml = toml::from_str(self.source()).map_err(|details| {
+            let span = details
+                .line_col()
+                .and_then(|(line, col)| self.span_for_line_col(line, col))
+                .unwrap_or((0..0).into());
+            AxoassetError::Toml {
+                source: self.clone(),
+                span,
+                details,
+            }
+        })?;
+        Ok(toml)
+    }
+
+    /// Get the name of a SourceFile
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+    /// Get the contents of a SourceFile
+    pub fn source(&self) -> &str {
+        &self.inner.source
+    }
+
+    /// Gets a proper [`SourceSpan`] from a line-and-column representation
+    ///
+    /// Both values are 1's based, so `(1, 1)` is the start of the file.
+    /// If anything underflows/overflows or goes out of bounds then we'll
+    /// just return `None`. `unwrap_or_default()` will give you the empty span from that.
+    ///
+    /// This is a pretty heavy-weight process, we have to basically linearly scan the source
+    /// for this position!
+    pub fn span_for_line_col(&self, line: usize, col: usize) -> Option<SourceSpan> {
+        let src = self.source();
+        let src_line = src.lines().nth(line.checked_sub(1)?)?;
+        if col > src_line.len() {
+            return None;
+        }
+        let src_addr = src.as_ptr() as usize;
+        let line_addr = src_line.as_ptr() as usize;
+        let line_offset = line_addr.checked_sub(src_addr)?;
+        let start = line_offset.checked_add(col)?.checked_sub(1)?;
+        let end = start.checked_add(1)?;
+        if start > end || end >= src.len() {
+            return None;
+        }
+        Some(SourceSpan::from(start..end))
+    }
+}
+
+impl SourceCode for SourceFile {
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> std::result::Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
+        let contents = self
+            .source()
+            .read_span(span, context_lines_before, context_lines_after)?;
+        Ok(Box::new(MietteSpanContents::new_named(
+            self.name().to_owned(),
+            contents.data(),
+            *contents.span(),
+            contents.line(),
+            contents.column(),
+            contents.line_count(),
+        )))
+    }
+}
+
+impl Debug for SourceFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SourceFile")
+            .field("name", &self.name())
+            .field("source", &self.source())
+            .finish()
+    }
+}

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,0 +1,227 @@
+use std::{
+    borrow::Borrow,
+    cmp::Ordering,
+    fmt::{self, Display},
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
+};
+
+use miette::SourceSpan;
+#[cfg(feature = "toml-serde")]
+use serde::{de, ser};
+
+/// A spanned value, indicating the range at which it is defined in the source.
+#[derive(Clone, Default)]
+pub struct Spanned<T> {
+    start: usize,
+    end: usize,
+    value: T,
+}
+
+impl<T> Spanned<T> {
+    /// Create a Spanned with a specific SourceSpan.
+    pub fn with_source_span(value: T, source: SourceSpan) -> Self {
+        Spanned {
+            start: source.offset(),
+            end: source.offset() + source.len(),
+            value,
+        }
+    }
+
+    /// Access the start of the span of the contained value.
+    pub fn start(this: &Self) -> usize {
+        this.start
+    }
+
+    /// Access the end of the span of the contained value.
+    pub fn end(this: &Self) -> usize {
+        this.end
+    }
+
+    /// Update the span
+    pub fn update_span(this: &mut Self, start: usize, end: usize) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /// Alter a span to a length anchored from the end.
+    pub fn from_end(mut this: Self, length: usize) -> Self {
+        this.start = this.end - length;
+        this
+    }
+
+    /// Get the span of the contained value.
+    pub fn span(this: &Self) -> SourceSpan {
+        (Self::start(this)..Self::end(this)).into()
+    }
+
+    /// Consumes the spanned value and returns the contained value.
+    pub fn into_inner(this: Self) -> T {
+        this.value
+    }
+}
+
+impl<T> IntoIterator for Spanned<T>
+where
+    T: IntoIterator,
+{
+    type IntoIter = T::IntoIter;
+    type Item = T::Item;
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Spanned<T>
+where
+    &'a T: IntoIterator,
+{
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+    type Item = <&'a T as IntoIterator>::Item;
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Spanned<T>
+where
+    &'a mut T: IntoIterator,
+{
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+    type Item = <&'a mut T as IntoIterator>::Item;
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<T> fmt::Debug for Spanned<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<T> Display for Spanned<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<T> Deref for Spanned<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for Spanned<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl Borrow<str> for Spanned<String> {
+    fn borrow(&self) -> &str {
+        self
+    }
+}
+
+impl<T> Borrow<T> for Spanned<T> {
+    fn borrow(&self) -> &T {
+        self
+    }
+}
+
+impl<T, U: ?Sized> AsRef<U> for Spanned<T>
+where
+    T: AsRef<U>,
+{
+    fn as_ref(&self) -> &U {
+        self.value.as_ref()
+    }
+}
+
+impl<T: PartialEq> PartialEq for Spanned<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+impl<T: PartialEq<T>> PartialEq<T> for Spanned<T> {
+    fn eq(&self, other: &T) -> bool {
+        self.value.eq(other)
+    }
+}
+
+impl<T: Eq> Eq for Spanned<T> {}
+
+impl<T: Hash> Hash for Spanned<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for Spanned<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<T: PartialOrd<T>> PartialOrd<T> for Spanned<T> {
+    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
+        self.value.partial_cmp(other)
+    }
+}
+
+impl<T: Ord> Ord for Spanned<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<T> From<T> for Spanned<T> {
+    fn from(value: T) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            value,
+        }
+    }
+}
+
+#[cfg(feature = "toml-serde")]
+impl<T> From<toml::Spanned<T>> for Spanned<T> {
+    fn from(value: toml::Spanned<T>) -> Self {
+        let span = value.span();
+        Self {
+            start: span.0,
+            end: span.1,
+            value: value.into_inner(),
+        }
+    }
+}
+
+#[cfg(feature = "toml-serde")]
+impl<'de, T: de::Deserialize<'de>> de::Deserialize<'de> for Spanned<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Ok(toml::Spanned::<T>::deserialize(deserializer)?.into())
+    }
+}
+
+#[cfg(feature = "toml-serde")]
+impl<T: ser::Serialize> ser::Serialize for Spanned<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}


### PR DESCRIPTION
based on top of #24 (only the last "merge axoerror..." commit is new)

This introduces a `SourceFile` type which is basically a readonly String version of Asset wrapped in an Arc. The purpose of this type is to be cheap to clone and pass around everywhere so that errors can refer to it (using the miette `#[source_code]` and `#[label]` attributes). The Arc ensures this is cheap at minimal overhead. The String ensures the contents make sense to display.

I don't think any types should be unified here, they all make sense to exist on their own. For instance images should never be SourceFiles. That said I expect anything working with text files will probably prefer to work with SourceFile?

This also introduces a `Spanned<T>` type which tries to behave like `Box<T>` in the sense that it's "as if" it's a `T` but with source span info embedded. The idea is that if you want to remember that a value was decoded from bytes 100 to 200 of whatever file, you can wrap it in a `Spanned` without disrupting any of the code that uses it. Then if you determine that value caused a problem, you can call `Spanned::span(&value)` to extract the span and have miette include the source_file context in the error message.

This also adds two features: `json-serde` and `toml-serde` which pull in dedicated support for `serde_json` and `toml-rs`.

These features add `deserialize_json` and `deserialize_toml` methods to SourceFile which understand those crates' native error types and produce full pretty miette-y errors when deserializing, like this:

```
  × failed to read JSON
  ╰─▶ trailing comma at line 3 column 1
   ╭─[src/tests/res/bad-package.json:2:1]
 2 │     "name": null,
 3 │ }
   · ─
   ╰────
```

(In this case serde_json itself points at the close brace and not the actual comma, we're just faithfully forwarding that.)

`Spanned` has special integration with `toml-rs`, because it's actually a fork of that crate's [own magic `Spanned` type](https://docs.rs/toml/latest/toml/struct.Spanned.html). Basically if you deserialize a struct that contains a `Spanned<T>` it will automagically fill in the span info for you. Ours is just better because it puts in more effort to be totally transparent like Box.

Some utility fs operations were also stapled onto LocalAsset so that axoproject doesn't implement them (current_dir and search_ancestors). I'm pretty sure everything we write can also make use of these.

This also driveby introduces some uses of camino/Utf8Path but I wasn't willing to factor everything (and it's messier when it comes to things that can interact with RemoteAsset).