### PR TITLE
feat: add more methods used in `cargo-dist`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ toml = { version = "0.5.9", optional = true }
 serde_json = { version = "1.0.95", optional = true }
 serde = { version = "1.0.159", optional = true, features = ["derive"] }
 camino = "1.1.4"
+tar = "0.4.38"
+zip = "0.6.4"
+flate2 = "1.0.25"
+xz2 = "0.1.7"
 
 [dev-dependencies]
 assert_fs = "1"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,226 @@
+//! Compression-related methods, all used in `axoasset::Local`
+
+use crate::error::*;
+use camino::Utf8Path;
+use flate2::{write::ZlibEncoder, Compression, GzBuilder};
+use std::{
+    fs::{self, DirEntry},
+    io::BufReader,
+};
+use xz2::write::XzEncoder;
+use zip::ZipWriter;
+
+/// Internal tar-file compression algorithms
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum CompressionImpl {
+    /// .gz
+    Gzip,
+    /// .xz
+    Xzip,
+    /// .zstd
+    Zstd,
+}
+
+pub(crate) fn tar_dir(
+    src_path: &Utf8Path,
+    dest_path: &Utf8Path,
+    compression: &CompressionImpl,
+) -> Result<()> {
+    // Set up the archive/compression
+    // The contents of the zip (e.g. a tar)
+    let dir_name = src_path.file_name().unwrap();
+    let zip_contents_name = format!("{dir_name}.tar");
+    let final_zip_file = match fs::File::create(dest_path) {
+        Ok(file) => file,
+        Err(details) => {
+            return Err(AxoassetError::LocalAssetWriteNewFailed {
+                dest_path: dest_path.to_string(),
+                details,
+            })
+        }
+    };
+
+    match compression {
+        CompressionImpl::Gzip => {
+            // Wrap our file in compression
+            let zip_output = GzBuilder::new()
+                .filename(zip_contents_name)
+                .write(final_zip_file, Compression::default());
+
+            // Write the tar to the compression stream
+            let mut tar = tar::Builder::new(zip_output);
+
+            // Add the whole dir to the tar
+            if let Err(details) = tar.append_dir_all(dir_name, src_path) {
+                return Err(AxoassetError::LocalAssetArchive {
+                    reason: format!("failed to copy directory into tar: {src_path} => {dir_name}",),
+                    details,
+                });
+            }
+            // Finish up the tarring
+            let zip_output = match tar.into_inner() {
+                Ok(out) => out,
+                Err(details) => {
+                    return Err(AxoassetError::LocalAssetArchive {
+                        reason: format!("failed to write tar: {dest_path}"),
+                        details,
+                    })
+                }
+            };
+            // Finish up the compression
+            let _zip_file = match zip_output.finish() {
+                Ok(file) => file,
+                Err(details) => {
+                    return Err(AxoassetError::LocalAssetArchive {
+                        reason: format!("failed to write archive: {dest_path}"),
+                        details,
+                    })
+                }
+            };
+            // Drop the file to close it
+        }
+        CompressionImpl::Xzip => {
+            let zip_output = XzEncoder::new(final_zip_file, 9);
+            // Write the tar to the compression stream
+            let mut tar = tar::Builder::new(zip_output);
+
+            // Add the whole dir to the tar
+            if let Err(details) = tar.append_dir_all(dir_name, src_path) {
+                return Err(AxoassetError::LocalAssetArchive {
+                    reason: format!("failed to copy directory into tar: {src_path} => {dir_name}",),
+                    details,
+                });
+            }
+            // Finish up the tarring
+            let zip_output = match tar.into_inner() {
+                Ok(out) => out,
+                Err(details) => {
+                    return Err(AxoassetError::LocalAssetArchive {
+                        reason: format!("failed to write tar: {dest_path}"),
+                        details,
+                    })
+                }
+            };
+            // Finish up the compression
+            let _zip_file = match zip_output.finish() {
+                Ok(file) => file,
+                Err(details) => {
+                    return Err(AxoassetError::LocalAssetArchive {
+                        reason: format!("failed to write archive: {dest_path}"),
+                        details,
+                    })
+                }
+            };
+            // Drop the file to close it
+        }
+        CompressionImpl::Zstd => {
+            // Wrap our file in compression
+            let zip_output = ZlibEncoder::new(final_zip_file, Compression::default());
+
+            // Write the tar to the compression stream
+            let mut tar = tar::Builder::new(zip_output);
+
+            // Add the whole dir to the tar
+            if let Err(details) = tar.append_dir_all(dir_name, src_path) {
+                return Err(AxoassetError::LocalAssetArchive {
+                    reason: format!("failed to copy directory into tar: {src_path} => {dir_name}",),
+                    details,
+                });
+            }
+            // Finish up the tarring
+            let zip_output = match tar.into_inner() {
+                Ok(out) => out,
+                Err(details) => {
+                    return Err(AxoassetError::LocalAssetArchive {
+                        reason: format!("failed to write tar: {dest_path}"),
+                        details,
+                    })
+                }
+            };
+            // Finish up the compression
+            let _zip_file = match zip_output.finish() {
+                Ok(file) => file,
+                Err(details) => {
+                    return Err(AxoassetError::LocalAssetArchive {
+                        reason: format!("failed to write archive: {dest_path}"),
+                        details,
+                    })
+                }
+            };
+            // Drop the file to close it
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn zip_dir(src_path: &Utf8Path, dest_path: &Utf8Path) -> Result<()> {
+    // Set up the archive/compression
+    let final_zip_file = match fs::File::create(dest_path) {
+        Ok(file) => file,
+        Err(details) => {
+            return Err(AxoassetError::LocalAssetWriteNewFailed {
+                dest_path: dest_path.to_string(),
+                details,
+            })
+        }
+    };
+
+    // Wrap our file in compression
+    let mut zip = ZipWriter::new(final_zip_file);
+
+    let dir = match std::fs::read_dir(src_path) {
+        Ok(dir) => dir,
+        Err(details) => {
+            return Err(AxoassetError::LocalAssetReadFailed {
+                origin_path: src_path.to_string(),
+                details,
+            })
+        }
+    };
+
+    for entry in dir {
+        if let Err(details) = copy_into_zip(entry, &mut zip) {
+            return Err(AxoassetError::LocalAssetArchive {
+                reason: format!("failed to create file in zip: {dest_path}"),
+                details,
+            });
+        }
+    }
+
+    // Finish up the compression
+    let _zip_file = match zip.finish() {
+        Ok(file) => file,
+        Err(details) => {
+            return Err(AxoassetError::LocalAssetArchive {
+                reason: format!("failed to write archive: {dest_path}"),
+                details: details.into(),
+            })
+        }
+    };
+    // Drop the file to close it
+    Ok(())
+}
+
+/// Copies a file into a provided `ZipWriter`. Mostly factored out so that we can bunch up
+/// a bunch of `std::io::Error`s without having to individually handle them.
+fn copy_into_zip(
+    entry: std::result::Result<DirEntry, std::io::Error>,
+    zip: &mut ZipWriter<fs::File>,
+) -> std::result::Result<(), std::io::Error> {
+    let entry = entry?;
+    if entry.file_type()?.is_file() {
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let file = fs::File::open(entry.path())?;
+        let mut buf = BufReader::new(file);
+        let file_name = entry.file_name();
+        // FIXME: ...don't do this lossy conversion?
+        let utf8_file_name = file_name.to_string_lossy();
+        zip.start_file(utf8_file_name.clone(), options)?;
+        std::io::copy(&mut buf, zip)?;
+    } else {
+        todo!("implement zip subdirs! (or was this a symlink?)");
+    }
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -222,11 +222,20 @@ pub enum AxoassetError {
 
     /// This error indicates that axoasset failed to write a new asset
     #[error("failed to write a new asset to {dest_path}.")]
-    #[diagnostic(help(
-        "Make sure your destination path is relative to your oranda config or project manifest file."
-    ))]
+    #[diagnostic(help("Make sure you have the correct rights to create a new file."))]
     LocalAssetWriteNewFailed {
         /// The path where the asset was being written to
+        dest_path: String,
+        /// Details of the error
+        #[source]
+        details: std::io::Error,
+    },
+
+    /// This error indicates that axoasset failed to create a new directory
+    #[error("failed to write a new directory to {dest_path}.")]
+    #[diagnostic(help("Make sure you have the correct rights to create a new directory."))]
+    LocalAssetDirCreationFailed {
+        /// The path where the directory was meant to be created
         dest_path: String,
         /// Details of the error
         #[source]

--- a/src/error.rs
+++ b/src/error.rs
@@ -222,7 +222,7 @@ pub enum AxoassetError {
 
     /// This error indicates that axoasset failed to write a new asset
     #[error("failed to write a new asset to {dest_path}.")]
-    #[diagnostic(help("Make sure you have the correct rights to create a new file."))]
+    #[diagnostic(help("Make sure you have the correct permissons to create a new file."))]
     LocalAssetWriteNewFailed {
         /// The path where the asset was being written to
         dest_path: String,
@@ -233,7 +233,7 @@ pub enum AxoassetError {
 
     /// This error indicates that axoasset failed to create a new directory
     #[error("failed to write a new directory to {dest_path}.")]
-    #[diagnostic(help("Make sure you have the correct rights to create a new directory."))]
+    #[diagnostic(help("Make sure you have the correct permissions to create a new directory."))]
     LocalAssetDirCreationFailed {
         /// The path where the directory was meant to be created
         dest_path: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,7 +76,7 @@ pub enum AxoassetError {
     },
 
     /// This error indicates that the mime type of the requested remote asset
-    /// was not an image.  
+    /// was not an image.
     #[error("when fetching asset at {origin_path}, the server's response mime type did not indicate an image.")]
     #[help(
         "Please make sure the asset url is correct and that the server is properly configured."
@@ -227,6 +227,19 @@ pub enum AxoassetError {
     ))]
     LocalAssetWriteNewFailed {
         /// The path where the asset was being written to
+        dest_path: String,
+        /// Details of the error
+        #[source]
+        details: std::io::Error,
+    },
+
+    /// This error indicates that axoasset failed to delete an asset
+    #[error("failed to delete asset at {dest_path}.")]
+    #[diagnostic(help(
+        "Make sure your path is relative to your oranda config or project manifest file."
+    ))]
+    LocalAssetRemoveFailed {
+        /// The path that was going to be deleted
         dest_path: String,
         /// Details of the error
         #[source]

--- a/src/error.rs
+++ b/src/error.rs
@@ -256,6 +256,20 @@ pub enum AxoassetError {
         /// The origin path of the asset, used as an identifier
         origin_path: String,
     },
+
+    /// This error indicates we ran into an issue when creating an archive.
+    #[error("failed to create archive: {reason}")]
+    #[diagnostic(help(
+        "Make sure your path is relative to your oranda config or project manifest file."
+    ))]
+    LocalAssetArchive {
+        /// A specific step that failed
+        reason: String,
+        /// Details of the error
+        #[source]
+        details: std::io::Error,
+    },
+
     /// This error indicates we ran `std::env::current_dir` and somehow got an error.
     #[error("Failed to get the current working directory")]
     CurrentDir {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 
 use std::path::PathBuf;
 
+pub(crate) mod compression;
 pub(crate) mod error;
 pub(crate) mod local;
 #[cfg(feature = "remote")]

--- a/src/local.rs
+++ b/src/local.rs
@@ -136,7 +136,7 @@ impl LocalAsset {
         let dest_path = PathBuf::from(dest);
         match fs::create_dir(&dest_path) {
             Ok(_) => Ok(dest_path),
-            Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
+            Err(details) => Err(AxoassetError::LocalAssetDirCreationFailed {
                 dest_path: dest_path.display().to_string(),
                 details,
             }),
@@ -148,7 +148,7 @@ impl LocalAsset {
         let dest_path = PathBuf::from(dest);
         match fs::create_dir_all(&dest_path) {
             Ok(_) => Ok(dest_path),
-            Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
+            Err(details) => Err(AxoassetError::LocalAssetDirCreationFailed {
                 dest_path: dest_path.display().to_string(),
                 details,
             }),

--- a/src/local.rs
+++ b/src/local.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
+use crate::compression::{tar_dir, zip_dir, CompressionImpl};
 use crate::error::*;
 
 /// A local asset contains a path on the local filesystem and its contents
@@ -223,6 +224,38 @@ impl LocalAsset {
                 origin_path: origin_path.to_string(),
             })
         }
+    }
+
+    /// Creates a new .tar.gz file from a provided directory
+    pub fn tar_gz_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
+        tar_dir(
+            Utf8Path::new(origin_dir),
+            Utf8Path::new(dest_dir),
+            &CompressionImpl::Gzip,
+        )
+    }
+
+    /// Creates a new .tar.xz file from a provided directory
+    pub fn tar_xz_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
+        tar_dir(
+            Utf8Path::new(origin_dir),
+            Utf8Path::new(dest_dir),
+            &CompressionImpl::Xzip,
+        )
+    }
+
+    /// Creates a new .tar.zstd file from a provided directory
+    pub fn tar_zstd_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
+        tar_dir(
+            Utf8Path::new(origin_dir),
+            Utf8Path::new(dest_dir),
+            &CompressionImpl::Zstd,
+        )
+    }
+
+    /// Creates a new .zip file from a provided directory
+    pub fn zip_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
+        zip_dir(Utf8Path::new(origin_dir), Utf8Path::new(dest_dir))
     }
 
     fn dest_path(&self, dest_dir: &str) -> Result<PathBuf> {

--- a/src/local.rs
+++ b/src/local.rs
@@ -106,6 +106,15 @@ impl LocalAsset {
     /// filename from the origin path
     pub fn write_new(contents: &str, filename: &str, dest_dir: &str) -> Result<PathBuf> {
         let dest_path = Path::new(dest_dir).join(filename);
+        match fs::create_dir_all(dest_dir) {
+            Ok(_) => (),
+            Err(details) => {
+                return Err(AxoassetError::LocalAssetWriteNewFailed {
+                    dest_path: dest_path.display().to_string(),
+                    details,
+                })
+            }
+        }
         match fs::write(&dest_path, contents) {
             Ok(_) => Ok(dest_path),
             Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
@@ -113,6 +122,40 @@ impl LocalAsset {
                 details,
             }),
         }
+    }
+
+    /// Creates a new directory, including all parent directories
+    pub fn create_directory(dest: &str) -> Result<PathBuf> {
+        let dest_path = PathBuf::from(dest);
+        match fs::create_dir_all(&dest_path) {
+            Ok(_) => Ok(dest_path),
+            Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
+                dest_path: dest_path.display().to_string(),
+                details,
+            }),
+        }
+    }
+
+    /// Removes a file or directory
+    pub fn remove(dest: &str) -> Result<()> {
+        let dest_path = PathBuf::from(dest);
+        if dest_path.is_dir() {
+            if let Err(details) = fs::remove_dir_all(&dest_path) {
+                return Err(AxoassetError::LocalAssetRemoveFailed {
+                    dest_path: dest_path.display().to_string(),
+                    details,
+                });
+            }
+        } else {
+            if let Err(details) = fs::remove_file(&dest_path) {
+                return Err(AxoassetError::LocalAssetRemoveFailed {
+                    dest_path: dest_path.display().to_string(),
+                    details,
+                });
+            }
+        }
+
+        Ok(())
     }
 
     /// Copies an asset from one location on the local filesystem to another

--- a/src/local.rs
+++ b/src/local.rs
@@ -107,15 +107,6 @@ impl LocalAsset {
     /// filename from the origin path
     pub fn write_new(contents: &str, filename: &str, dest_dir: &str) -> Result<PathBuf> {
         let dest_path = Path::new(dest_dir).join(filename);
-        match fs::create_dir_all(dest_dir) {
-            Ok(_) => (),
-            Err(details) => {
-                return Err(AxoassetError::LocalAssetWriteNewFailed {
-                    dest_path: dest_path.display().to_string(),
-                    details,
-                })
-            }
-        }
         match fs::write(&dest_path, contents) {
             Ok(_) => Ok(dest_path),
             Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
@@ -125,8 +116,35 @@ impl LocalAsset {
         }
     }
 
-    /// Creates a new directory, including all parent directories
+    /// Writes an asset and all of its parent directories on the local filesystem.
+    pub fn write_new_all(contents: &str, filename: &str, dest_dir: &str) -> Result<PathBuf> {
+        let dest_path = Path::new(dest_dir).join(filename);
+        match fs::create_dir_all(dest_dir) {
+            Ok(_) => (),
+            Err(details) => {
+                return Err(AxoassetError::LocalAssetWriteNewFailed {
+                    dest_path: dest_path.display().to_string(),
+                    details,
+                })
+            }
+        }
+        LocalAsset::write_new(contents, filename, dest_dir)
+    }
+
+    /// Creates a new directory
     pub fn create_directory(dest: &str) -> Result<PathBuf> {
+        let dest_path = PathBuf::from(dest);
+        match fs::create_dir(&dest_path) {
+            Ok(_) => Ok(dest_path),
+            Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
+                dest_path: dest_path.display().to_string(),
+                details,
+            }),
+        }
+    }
+
+    /// Creates a new directory, including all parent directories
+    pub fn create_directory_all(dest: &str) -> Result<PathBuf> {
         let dest_path = PathBuf::from(dest);
         match fs::create_dir_all(&dest_path) {
             Ok(_) => Ok(dest_path),

--- a/src/local.rs
+++ b/src/local.rs
@@ -155,8 +155,36 @@ impl LocalAsset {
         }
     }
 
-    /// Removes a file or directory
-    pub fn remove(dest: &str) -> Result<()> {
+    /// Removes a file
+    pub fn remove_file(dest: &str) -> Result<()> {
+        let dest_path = PathBuf::from(dest);
+        if let Err(details) = fs::remove_file(&dest_path) {
+            return Err(AxoassetError::LocalAssetRemoveFailed {
+                dest_path: dest_path.display().to_string(),
+                details,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Removes a directory
+    pub fn remove_dir(dest: &str) -> Result<()> {
+        let dest_path = PathBuf::from(dest);
+        if dest_path.is_dir() {
+            if let Err(details) = fs::remove_dir(&dest_path) {
+                return Err(AxoassetError::LocalAssetRemoveFailed {
+                    dest_path: dest_path.display().to_string(),
+                    details,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Removes a directory and all of its contents
+    pub fn remove_dir_all(dest: &str) -> Result<()> {
         let dest_path = PathBuf::from(dest);
         if dest_path.is_dir() {
             if let Err(details) = fs::remove_dir_all(&dest_path) {
@@ -165,11 +193,6 @@ impl LocalAsset {
                     details,
                 });
             }
-        } else if let Err(details) = fs::remove_file(&dest_path) {
-            return Err(AxoassetError::LocalAssetRemoveFailed {
-                dest_path: dest_path.display().to_string(),
-                details,
-            });
         }
 
         Ok(())

--- a/src/local.rs
+++ b/src/local.rs
@@ -147,13 +147,11 @@ impl LocalAsset {
                     details,
                 });
             }
-        } else {
-            if let Err(details) = fs::remove_file(&dest_path) {
-                return Err(AxoassetError::LocalAssetRemoveFailed {
-                    dest_path: dest_path.display().to_string(),
-                    details,
-                });
-            }
+        } else if let Err(details) = fs::remove_file(&dest_path) {
+            return Err(AxoassetError::LocalAssetRemoveFailed {
+                dest_path: dest_path.display().to_string(),
+                details,
+            });
         }
 
         Ok(())

--- a/tests/local_new.rs
+++ b/tests/local_new.rs
@@ -32,3 +32,30 @@ async fn it_creates_new_assets() {
         }
     }
 }
+
+#[test]
+fn it_creates_parent_directories_on_write_new() {
+    let dest = assert_fs::TempDir::new().unwrap();
+
+    let dest_dir = Path::new(&dest.as_os_str())
+        .join("subdir")
+        .join("test.md")
+        .display()
+        .to_string();
+    axoasset::LocalAsset::write_new("file content", "index.md", &dest_dir).unwrap();
+
+    assert!(Path::new(&dest.as_os_str()).join("subdir").exists());
+}
+
+#[test]
+fn it_creates_a_new_directory() {
+    let dest = assert_fs::TempDir::new().unwrap();
+
+    let dest_dir = Path::new(&dest.as_os_str())
+        .join("subdir")
+        .display()
+        .to_string();
+    axoasset::LocalAsset::create_directory(&dest_dir).unwrap();
+
+    assert!(Path::new(&dest.as_os_str()).join("subdir").exists());
+}

--- a/tests/local_new.rs
+++ b/tests/local_new.rs
@@ -34,7 +34,7 @@ async fn it_creates_new_assets() {
 }
 
 #[test]
-fn it_creates_parent_directories_on_write_new() {
+fn it_creates_parent_directories() {
     let dest = assert_fs::TempDir::new().unwrap();
 
     let dest_dir = Path::new(&dest.as_os_str())
@@ -42,7 +42,7 @@ fn it_creates_parent_directories_on_write_new() {
         .join("test.md")
         .display()
         .to_string();
-    axoasset::LocalAsset::write_new("file content", "index.md", &dest_dir).unwrap();
+    axoasset::LocalAsset::write_new_all("file content", "index.md", &dest_dir).unwrap();
 
     assert!(Path::new(&dest.as_os_str()).join("subdir").exists());
 }

--- a/tests/local_remove.rs
+++ b/tests/local_remove.rs
@@ -7,12 +7,12 @@ fn it_removes_both_file_and_directory() {
     let file_path = Path::new(&dest.as_os_str()).join("subdir").join("test.md");
     let dir_path = Path::new(&dest.as_os_str()).join("subdir");
 
-    fs::create_dir_all(&file_path.parent().unwrap());
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
     fs::write(&file_path, "hello").unwrap();
 
-    axoasset::LocalAsset::remove(&file_path.display().to_string());
+    axoasset::LocalAsset::remove(&file_path.display().to_string()).unwrap();
     assert!(!file_path.exists());
 
-    axoasset::LocalAsset::remove(&dir_path.display().to_string());
+    axoasset::LocalAsset::remove(&dir_path.display().to_string()).unwrap();
     assert!(!dir_path.exists());
 }

--- a/tests/local_remove.rs
+++ b/tests/local_remove.rs
@@ -1,0 +1,18 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn it_removes_both_file_and_directory() {
+    let dest = assert_fs::TempDir::new().unwrap();
+    let file_path = Path::new(&dest.as_os_str()).join("subdir").join("test.md");
+    let dir_path = Path::new(&dest.as_os_str()).join("subdir");
+
+    fs::create_dir_all(&file_path.parent().unwrap());
+    fs::write(&file_path, "hello").unwrap();
+
+    axoasset::LocalAsset::remove(&file_path.display().to_string());
+    assert!(!file_path.exists());
+
+    axoasset::LocalAsset::remove(&dir_path.display().to_string());
+    assert!(!dir_path.exists());
+}

--- a/tests/local_remove.rs
+++ b/tests/local_remove.rs
@@ -10,9 +10,9 @@ fn it_removes_both_file_and_directory() {
     fs::create_dir_all(file_path.parent().unwrap()).unwrap();
     fs::write(&file_path, "hello").unwrap();
 
-    axoasset::LocalAsset::remove(&file_path.display().to_string()).unwrap();
+    axoasset::LocalAsset::remove_file(&file_path.display().to_string()).unwrap();
     assert!(!file_path.exists());
 
-    axoasset::LocalAsset::remove(&dir_path.display().to_string()).unwrap();
+    axoasset::LocalAsset::remove_dir(&dir_path.display().to_string()).unwrap();
     assert!(!dir_path.exists());
 }


### PR DESCRIPTION
Adds:

- Parent directory creation to `LocalAsset::write_new`,
- `LocalAsset::create_directory` to create a single directory,
- `LocalAsset::remove` to remove a file/directory,
- `LocalAsset::tar_[gz,xz,zstd]_dir` to create tar archives,
- `LocalAsset::zip_dir` to create zip archives

This should replace _most_ of the existing fs code within cargo-dist, which would be the next step after merging and cutting a release.