### PR TITLE
feat: separate compression into cargo features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ default = ["remote"]
 toml-serde = ["toml", "serde"]
 json-serde = ["serde_json", "serde"]
 remote = ["reqwest"]
+compression = ["compression-tar", "compression-zip"]
+compression-tar = ["flate2", "tar", "xz2"]
+compression-zip = ["zip"]
 
 [dependencies]
 image = "0.24.5"
@@ -18,15 +21,15 @@ reqwest = { version = "0.11.13", optional = true, features = ["json"] }
 thiserror = "1.0.37"
 url = "2.3.1"
 miette = "5.6.0"
+camino = "1.1.4"
 
 toml = { version = "0.5.9", optional = true }
 serde_json = { version = "1.0.95", optional = true }
 serde = { version = "1.0.159", optional = true, features = ["derive"] }
-camino = "1.1.4"
-tar = "0.4.38"
-zip = "0.6.4"
-flate2 = "1.0.25"
-xz2 = "0.1.7"
+tar = { version = "0.4.38", optional = true }
+zip = { version = "0.6.4", optional = true }
+flate2 = { version = "1.0.25", optional = true }
+xz2 = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
 assert_fs = "1"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -5,7 +5,7 @@ use camino::Utf8Path;
 use std::fs;
 
 /// Internal tar-file compression algorithms
-#[cfg(any(feature = "compression", feature = "compression-tar"))]
+#[cfg(feature = "compression-tar")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum CompressionImpl {
     /// .gz
@@ -16,7 +16,7 @@ pub(crate) enum CompressionImpl {
     Zstd,
 }
 
-#[cfg(any(feature = "compression", feature = "compression-tar"))]
+#[cfg(feature = "compression-tar")]
 pub(crate) fn tar_dir(
     src_path: &Utf8Path,
     dest_path: &Utf8Path,
@@ -153,7 +153,7 @@ pub(crate) fn tar_dir(
     Ok(())
 }
 
-#[cfg(any(feature = "compression", feature = "compression-zip"))]
+#[cfg(feature = "compression-zip")]
 pub(crate) fn zip_dir(src_path: &Utf8Path, dest_path: &Utf8Path) -> Result<()> {
     use zip::ZipWriter;
 
@@ -206,7 +206,7 @@ pub(crate) fn zip_dir(src_path: &Utf8Path, dest_path: &Utf8Path) -> Result<()> {
 
 /// Copies a file into a provided `ZipWriter`. Mostly factored out so that we can bunch up
 /// a bunch of `std::io::Error`s without having to individually handle them.
-#[cfg(any(feature = "compression", feature = "compression-zip"))]
+#[cfg(feature = "compression-zip")]
 fn copy_into_zip(
     entry: std::result::Result<std::fs::DirEntry, std::io::Error>,
     zip: &mut zip::ZipWriter<fs::File>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,11 @@
 
 use std::path::PathBuf;
 
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-zip",
+    feature = "compression-tar"
+))]
 pub(crate) mod compression;
 pub(crate) mod error;
 pub(crate) mod local;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,7 @@
 
 use std::path::PathBuf;
 
-#[cfg(any(
-    feature = "compression",
-    feature = "compression-zip",
-    feature = "compression-tar"
-))]
+#[cfg(any(feature = "compression-zip", feature = "compression-tar"))]
 pub(crate) mod compression;
 pub(crate) mod error;
 pub(crate) mod local;

--- a/src/local.rs
+++ b/src/local.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-use crate::compression::{tar_dir, zip_dir, CompressionImpl};
 use crate::error::*;
 
 /// A local asset contains a path on the local filesystem and its contents
@@ -266,35 +265,39 @@ impl LocalAsset {
     }
 
     /// Creates a new .tar.gz file from a provided directory
+    #[cfg(any(feature = "compression", feature = "compression-tar"))]
     pub fn tar_gz_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
-        tar_dir(
+        crate::compression::tar_dir(
             Utf8Path::new(origin_dir),
             Utf8Path::new(dest_dir),
-            &CompressionImpl::Gzip,
+            &crate::compression::CompressionImpl::Gzip,
         )
     }
 
     /// Creates a new .tar.xz file from a provided directory
+    #[cfg(any(feature = "compression", feature = "compression-tar"))]
     pub fn tar_xz_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
-        tar_dir(
+        crate::compression::tar_dir(
             Utf8Path::new(origin_dir),
             Utf8Path::new(dest_dir),
-            &CompressionImpl::Xzip,
+            &crate::compression::CompressionImpl::Xzip,
         )
     }
 
     /// Creates a new .tar.zstd file from a provided directory
+    #[cfg(any(feature = "compression", feature = "compression-tar"))]
     pub fn tar_zstd_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
-        tar_dir(
+        crate::compression::tar_dir(
             Utf8Path::new(origin_dir),
             Utf8Path::new(dest_dir),
-            &CompressionImpl::Zstd,
+            &crate::compression::CompressionImpl::Zstd,
         )
     }
 
     /// Creates a new .zip file from a provided directory
+    #[cfg(any(feature = "compression", feature = "compression-zip"))]
     pub fn zip_dir(origin_dir: &str, dest_dir: &str) -> Result<()> {
-        zip_dir(Utf8Path::new(origin_dir), Utf8Path::new(dest_dir))
+        crate::compression::zip_dir(Utf8Path::new(origin_dir), Utf8Path::new(dest_dir))
     }
 
     fn dest_path(&self, dest_dir: &str) -> Result<PathBuf> {

--- a/src/local.rs
+++ b/src/local.rs
@@ -285,7 +285,7 @@ impl LocalAsset {
         crate::compression::tar_dir(
             Utf8Path::new(origin_dir.as_ref()),
             Utf8Path::new(dest_dir.as_ref()),
-            &crate::compression:CompressionImpl::Gzip,
+            &crate::compression::CompressionImpl::Gzip,
         )
     }
 


### PR DESCRIPTION
This PR hides compression features behind a feature flag (`compression`), which itself can be broken up into more granular features (`compression-tar` and `compression-zip`).