### PR TITLE
feat: refactor local function to use AsRef, simplify write arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode/

--- a/src/local.rs
+++ b/src/local.rs
@@ -103,32 +103,40 @@ impl LocalAsset {
         }
     }
 
-    /// Writes an asset to a path on the local filesystem, determines the
-    /// filename from the origin path
-    pub fn write_new(contents: &str, filename: &str, dest_dir: &str) -> Result<PathBuf> {
-        let dest_path = Path::new(dest_dir).join(filename);
+    /// Writes an asset to a path on the local filesystem
+    pub fn write_new(contents: &str, dest_path: &str) -> Result<PathBuf> {
+        if Path::new(dest_path).file_name().is_none() {
+            return Err(AxoassetError::LocalAssetMissingFilename {
+                origin_path: dest_path.to_string(),
+            });
+        }
         match fs::write(&dest_path, contents) {
-            Ok(_) => Ok(dest_path),
+            Ok(_) => Ok(dest_path.into()),
             Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
-                dest_path: dest_path.display().to_string(),
+                dest_path: dest_path.to_string(),
                 details,
             }),
         }
     }
 
     /// Writes an asset and all of its parent directories on the local filesystem.
-    pub fn write_new_all(contents: &str, filename: &str, dest_dir: &str) -> Result<PathBuf> {
-        let dest_path = Path::new(dest_dir).join(filename);
+    pub fn write_new_all(contents: &str, dest_path: &str) -> Result<PathBuf> {
+        if Path::new(dest_path).file_name().is_none() {
+            return Err(AxoassetError::LocalAssetMissingFilename {
+                origin_path: dest_path.to_string(),
+            });
+        }
+        let dest_dir = Path::new(dest_path).parent().unwrap();
         match fs::create_dir_all(dest_dir) {
             Ok(_) => (),
             Err(details) => {
                 return Err(AxoassetError::LocalAssetWriteNewFailed {
-                    dest_path: dest_path.display().to_string(),
+                    dest_path: dest_path.to_string(),
                     details,
                 })
             }
         }
-        LocalAsset::write_new(contents, filename, dest_dir)
+        LocalAsset::write_new(contents, dest_path)
     }
 
     /// Creates a new directory

--- a/src/local.rs
+++ b/src/local.rs
@@ -110,7 +110,7 @@ impl LocalAsset {
                 origin_path: dest_path.to_string(),
             });
         }
-        match fs::write(&dest_path, contents) {
+        match fs::write(dest_path, contents) {
             Ok(_) => Ok(dest_path.into()),
             Err(details) => Err(AxoassetError::LocalAssetWriteNewFailed {
                 dest_path: dest_path.to_string(),

--- a/src/source.rs
+++ b/src/source.rs
@@ -68,12 +68,12 @@ impl SourceFile {
     }
 
     /// SourceFile equivalent of [`LocalAsset::load`][]
-    pub fn load_local<'a>(origin_path: impl Into<&'a Utf8Path>) -> Result<SourceFile> {
-        let origin_path = origin_path.into();
+    pub fn load_local(origin_path: impl AsRef<Utf8Path>) -> Result<SourceFile> {
+        let origin_path = origin_path.as_ref();
         let contents = LocalAsset::load_string(origin_path.as_str())?;
         Ok(SourceFile {
             inner: Arc::new(SourceFileInner {
-                filename: LocalAsset::filename(origin_path.as_str())?,
+                filename: LocalAsset::filename(origin_path)?,
                 origin_path: origin_path.to_string(),
                 contents,
             }),

--- a/tests/local_new.rs
+++ b/tests/local_new.rs
@@ -37,12 +37,12 @@ async fn it_creates_new_assets() {
 fn it_creates_parent_directories() {
     let dest = assert_fs::TempDir::new().unwrap();
 
-    let dest_dir = Path::new(&dest.as_os_str())
+    let dest_path = Path::new(&dest.as_os_str())
         .join("subdir")
         .join("test.md")
         .display()
         .to_string();
-    axoasset::LocalAsset::write_new_all("file content", "index.md", &dest_dir).unwrap();
+    axoasset::LocalAsset::write_new_all("file content", &dest_path).unwrap();
 
     assert!(Path::new(&dest.as_os_str()).join("subdir").exists());
 }

--- a/tests/local_new.rs
+++ b/tests/local_new.rs
@@ -42,7 +42,7 @@ fn it_creates_parent_directories() {
         .join("test.md")
         .display()
         .to_string();
-    axoasset::LocalAsset::write_new_all("file content", &dest_path).unwrap();
+    axoasset::LocalAsset::write_new_all("file content", dest_path).unwrap();
 
     assert!(Path::new(&dest.as_os_str()).join("subdir").exists());
 }
@@ -55,7 +55,7 @@ fn it_creates_a_new_directory() {
         .join("subdir")
         .display()
         .to_string();
-    axoasset::LocalAsset::create_dir(&dest_dir).unwrap();
+    axoasset::LocalAsset::create_dir(dest_dir).unwrap();
 
     assert!(Path::new(&dest.as_os_str()).join("subdir").exists());
 }

--- a/tests/local_remove.rs
+++ b/tests/local_remove.rs
@@ -10,9 +10,9 @@ fn it_removes_both_file_and_directory() {
     fs::create_dir_all(file_path.parent().unwrap()).unwrap();
     fs::write(&file_path, "hello").unwrap();
 
-    axoasset::LocalAsset::remove_file(&file_path.display().to_string()).unwrap();
+    axoasset::LocalAsset::remove_file(file_path.display().to_string()).unwrap();
     assert!(!file_path.exists());
 
-    axoasset::LocalAsset::remove_dir(&dir_path.display().to_string()).unwrap();
+    axoasset::LocalAsset::remove_dir(dir_path.display().to_string()).unwrap();
     assert!(!dir_path.exists());
 }

--- a/tests/local_write.rs
+++ b/tests/local_write.rs
@@ -10,16 +10,14 @@ use image::ImageFormat;
 #[test]
 fn it_writes_a_new_file_from_string() {
     let dest = assert_fs::TempDir::new().unwrap();
-    let dest_dir = Path::new(dest.to_str().unwrap());
+    let dest_file = Path::new(dest.to_str().unwrap()).join("contents.txt");
 
-    let filename = "contents.txt";
     let contents = "CONTENTS";
-    axoasset::LocalAsset::write_new(contents, filename, &dest_dir.display().to_string()).unwrap();
-    let written_file = dest_dir.join(filename);
-    assert!(written_file.exists());
+    axoasset::LocalAsset::write_new(contents, dest_file.to_str().unwrap()).unwrap();
+    assert!(dest_file.exists());
 
     let loaded_contents =
-        axoasset::LocalAsset::load_string(&written_file.display().to_string()).unwrap();
+        axoasset::LocalAsset::load_string(&dest_file.display().to_string()).unwrap();
     assert!(loaded_contents.contains(contents));
 }
 

--- a/tests/local_write.rs
+++ b/tests/local_write.rs
@@ -17,7 +17,7 @@ fn it_writes_a_new_file_from_string() {
     assert!(dest_file.exists());
 
     let loaded_contents =
-        axoasset::LocalAsset::load_string(&dest_file.display().to_string()).unwrap();
+        axoasset::LocalAsset::load_string(dest_file.display().to_string()).unwrap();
     assert!(loaded_contents.contains(contents));
 }
 


### PR DESCRIPTION
Changes the signature of those two functions to not explicitly take a `filename` and a `dest_dir` argument, instead now taking a `dest_path` argument, from which we infer everything else.

These two functions aren't currently in use in axo code (outside of https://github.com/axodotdev/cargo-dist/pull/229), so changing the signatures should be fine, at least for our use, as long as we mark the change as breaking correspondingly.