### PR TITLE
feat(copy): add more copying APIs to LocalAsset

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,0 +1,89 @@
+//! Utilities for working with directories
+//!
+//! Right now just a wrapper around WalkDirs that does some utf8 conversions and strip_prefixing,
+//! since we always end up doing that.
+
+use crate::error::*;
+use camino::{Utf8Path, Utf8PathBuf};
+
+/// Walk through this dir's descendants with `walkdirs`
+pub fn walk_dir(dir: impl AsRef<Utf8Path>) -> AxoassetWalkDir {
+    let dir = dir.as_ref();
+    AxoassetWalkDir {
+        root_dir: dir.to_owned(),
+        inner: walkdir::WalkDir::new(dir),
+    }
+}
+
+/// Wrapper around [`walkdir::WalkDir`][].
+pub struct AxoassetWalkDir {
+    root_dir: Utf8PathBuf,
+    inner: walkdir::WalkDir,
+}
+
+/// Wrapper around [`walkdir::IntoIter`][].
+pub struct AxoassetIntoIter {
+    root_dir: Utf8PathBuf,
+    inner: walkdir::IntoIter,
+}
+
+/// Wrapper around [`walkdir::DirEntry`][].
+pub struct AxoassetDirEntry {
+    /// full path to the entry
+    pub full_path: Utf8PathBuf,
+    /// path to the entry relative to the dir passed to [`walk_dir`][].
+    pub rel_path: Utf8PathBuf,
+    /// Inner contents
+    pub entry: walkdir::DirEntry,
+}
+
+impl IntoIterator for AxoassetWalkDir {
+    type IntoIter = AxoassetIntoIter;
+    type Item = Result<AxoassetDirEntry>;
+    fn into_iter(self) -> Self::IntoIter {
+        AxoassetIntoIter {
+            root_dir: self.root_dir,
+            inner: self.inner.into_iter(),
+        }
+    }
+}
+
+impl Iterator for AxoassetIntoIter {
+    type Item = Result<AxoassetDirEntry>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|next| {
+            let entry = next.map_err(|e| AxoassetError::WalkDirFailed {
+                origin_path: self.root_dir.clone(),
+                details: e,
+            })?;
+
+            let full_path = Utf8PathBuf::from_path_buf(entry.path().to_owned())
+                .map_err(|details| AxoassetError::Utf8Path { path: details })?;
+            let rel_path = full_path
+                .strip_prefix(&self.root_dir)
+                .map_err(|_| AxoassetError::PathNesting {
+                    root_dir: self.root_dir.clone(),
+                    child_dir: full_path.clone(),
+                })?
+                .to_owned();
+
+            Ok(AxoassetDirEntry {
+                full_path,
+                rel_path,
+                entry,
+            })
+        })
+    }
+}
+
+impl std::ops::Deref for AxoassetDirEntry {
+    type Target = walkdir::DirEntry;
+    fn deref(&self) -> &Self::Target {
+        &self.entry
+    }
+}
+impl std::ops::DerefMut for AxoassetDirEntry {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entry
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -188,7 +188,7 @@ pub enum AxoassetError {
         dest_path: String,
         /// Details of the error
         #[source]
-        details: std::io::Error,
+        details: Option<std::io::Error>,
     },
 
     /// This error indicates that axoasset failed to read a local asset at the

--- a/src/error.rs
+++ b/src/error.rs
@@ -188,7 +188,7 @@ pub enum AxoassetError {
         dest_path: String,
         /// Details of the error
         #[source]
-        details: Option<std::io::Error>,
+        details: std::io::Error,
     },
 
     /// This error indicates that axoasset failed to read a local asset at the
@@ -292,6 +292,16 @@ pub enum AxoassetError {
         /// The problematic path
         path: std::path::PathBuf,
     },
+    /// This error indicates we tried to strip_prefix a path that should have been
+    /// a descendant of another, but it didn't work.
+    #[error("Child wasn't nested under its parent: {root_dir} => {child_dir}")]
+    #[diagnostic(help("Are symlinks involved?"))]
+    PathNesting {
+        /// The root/ancestor dir
+        root_dir: camino::Utf8PathBuf,
+        /// THe child/descendent path
+        child_dir: camino::Utf8PathBuf,
+    },
 
     #[error("Failed to find {desired_filename} in an ancestor of {start_dir}")]
     /// This error indicates we failed to find the desired file in an ancestor of the search dir.
@@ -300,6 +310,16 @@ pub enum AxoassetError {
         start_dir: camino::Utf8PathBuf,
         /// The filename we were searching for
         desired_filename: String,
+    },
+
+    #[error("Failed to walk to ancestor of {origin_path}")]
+    /// Walkdir failed to yield an entry
+    WalkDirFailed {
+        /// The root path we were trying to walkdirs
+        origin_path: camino::Utf8PathBuf,
+        /// Inner walkdir error
+        #[source]
+        details: walkdir::Error,
     },
 
     /// This error indicates we tried to deserialize some JSON with serde_json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 
 #[cfg(any(feature = "compression-zip", feature = "compression-tar"))]
 pub(crate) mod compression;
+pub(crate) mod dirs;
 pub(crate) mod error;
 pub(crate) mod local;
 #[cfg(feature = "remote")]
@@ -20,6 +21,7 @@ pub(crate) mod remote;
 pub(crate) mod source;
 pub(crate) mod spanned;
 
+use camino::Utf8PathBuf;
 pub use error::AxoassetError;
 use error::Result;
 pub use local::LocalAsset;
@@ -83,7 +85,7 @@ impl Asset {
 
     /// Copies an asset, returning the path to the copy destination on the
     /// local filesystem.
-    pub async fn copy(origin_path: &str, dest_dir: &str) -> Result<PathBuf> {
+    pub async fn copy(origin_path: &str, dest_dir: &str) -> Result<Utf8PathBuf> {
         #[cfg(feature = "remote")]
         if is_remote(origin_path)? {
             return RemoteAsset::copy(origin_path, dest_dir).await;

--- a/src/local.rs
+++ b/src/local.rs
@@ -294,8 +294,13 @@ impl LocalAsset {
             } else if entry.file_type().is_file() {
                 // copy files
                 LocalAsset::copy_named(from, to)?;
+            } else {
+                // other kinds of file presumed to be symlinks which we don't handle
+                debug_assert!(
+                    entry.file_type().is_symlink(),
+                    "unknown type of file at {from}, axoasset needs to be updated to support this!"
+                );
             }
-            // other kinds of file presumed to be symlinks which we don't handle
         }
         Ok(())
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use camino::{Utf8Path, Utf8PathBuf};
+
 use crate::error::*;
 
 /// A remote asset is an asset that is fetched over the network.
@@ -60,15 +62,15 @@ impl RemoteAsset {
     }
 
     /// Copies an asset to the local filesystem.
-    pub async fn copy(origin_path: &str, dest_dir: &str) -> Result<PathBuf> {
+    pub async fn copy(origin_path: &str, dest_dir: &str) -> Result<Utf8PathBuf> {
         match RemoteAsset::load(origin_path).await {
             Ok(a) => {
-                let dest_path = Path::new(dest_dir).join(a.filename);
+                let dest_path = Utf8Path::new(dest_dir).join(a.filename);
                 match fs::write(&dest_path, a.contents) {
                     Ok(_) => Ok(dest_path),
                     Err(details) => Err(AxoassetError::RemoteAssetWriteFailed {
                         origin_path: origin_path.to_string(),
-                        dest_path: dest_path.display().to_string(),
+                        dest_path: dest_path.to_string(),
                         details,
                     }),
                 }

--- a/tests/local_copy.rs
+++ b/tests/local_copy.rs
@@ -1,15 +1,15 @@
 #![allow(irrefutable_let_patterns)]
 
 use std::collections::HashMap;
-use std::path::Path;
 
 use assert_fs::prelude::*;
+use camino::Utf8Path;
 
 #[tokio::test]
 async fn it_copies_local_assets() {
     let origin = assert_fs::TempDir::new().unwrap();
     let dest = assert_fs::TempDir::new().unwrap();
-    let dest_dir = Path::new(dest.to_str().unwrap());
+    let dest_dir = Utf8Path::from_path(dest.path()).unwrap();
 
     let mut files = HashMap::new();
     files.insert("README.md", "# axoasset");
@@ -17,21 +17,128 @@ async fn it_copies_local_assets() {
 
     for (file, contents) in files {
         let asset = origin.child(file);
-        let content = Path::new("./tests/assets").join(file);
-        asset.write_file(&content).unwrap();
+        asset.write_str(contents).unwrap();
 
-        let origin_path = asset.to_str().unwrap();
-        axoasset::Asset::copy(origin_path, dest.to_str().unwrap())
+        axoasset::Asset::copy(asset.to_str().unwrap(), dest.to_str().unwrap())
             .await
             .unwrap();
 
         let copied_file = dest_dir.join(file);
         assert!(copied_file.exists());
-        let loaded_asset = axoasset::Asset::load(copied_file.to_str().unwrap())
-            .await
-            .unwrap();
+        let loaded_asset = axoasset::Asset::load(copied_file.as_str()).await.unwrap();
         if let axoasset::Asset::LocalAsset(asset) = loaded_asset {
             assert!(std::str::from_utf8(&asset.contents)
+                .unwrap()
+                .contains(contents));
+        }
+    }
+}
+
+#[tokio::test]
+async fn it_copies_named_local_assets() {
+    let origin = assert_fs::TempDir::new().unwrap();
+    let dest = assert_fs::TempDir::new().unwrap();
+    let dest_dir = Utf8Path::from_path(dest.path()).unwrap();
+
+    let mut files = HashMap::new();
+    files.insert("README.md", "# axoasset");
+    files.insert("styles.css", "@import");
+
+    for (file, contents) in files {
+        let asset = origin.child(file);
+        asset.write_str(contents).unwrap();
+
+        let origin_path = asset.to_str().unwrap();
+        axoasset::LocalAsset::copy_named(origin_path, dest_dir.join(file)).unwrap();
+
+        let copied_file = dest_dir.join(file);
+        assert!(copied_file.exists());
+        let loaded_asset = axoasset::LocalAsset::load(copied_file).unwrap();
+        assert!(std::str::from_utf8(&loaded_asset.contents)
+            .unwrap()
+            .contains(contents));
+    }
+}
+
+#[tokio::test]
+async fn it_copies_dirs() {
+    let origin = assert_fs::TempDir::new().unwrap().child("result");
+    let dest = assert_fs::TempDir::new().unwrap();
+    let origin_dir = Utf8Path::from_path(origin.path()).unwrap();
+    let dest_dir = Utf8Path::from_path(dest.path()).unwrap();
+    origin.create_dir_all().unwrap();
+
+    // None means it's just a dir, used to make sure empty dirs get copied
+    let mut files = HashMap::new();
+    files.insert("blah/blargh/README3.md", Some("# axoasset3"));
+    files.insert("blah/README2.md", Some("# axoasset2"));
+    files.insert("blah/README.md", Some("# axoasset"));
+    files.insert("styles.css", Some("@import"));
+    files.insert("blah/blargh/empty_dir", None);
+    files.insert("empty/dirs", None);
+    files.insert("root_empty", None);
+
+    for (file, contents) in &files {
+        let asset = origin.child(file);
+        if let Some(contents) = contents {
+            std::fs::create_dir_all(asset.parent().unwrap()).unwrap();
+            asset.write_str(contents).unwrap();
+        } else {
+            asset.create_dir_all().unwrap();
+        }
+    }
+
+    axoasset::LocalAsset::copy_dir(origin_dir, dest_dir).unwrap();
+
+    for (file, contents) in &files {
+        let copied_file = dest_dir.join("result").join(file);
+
+        assert!(copied_file.exists());
+        if let Some(contents) = contents {
+            let loaded_asset = axoasset::LocalAsset::load(copied_file).unwrap();
+            assert!(std::str::from_utf8(&loaded_asset.contents)
+                .unwrap()
+                .contains(contents));
+        }
+    }
+}
+
+#[tokio::test]
+async fn it_copies_named_dirs() {
+    let origin = assert_fs::TempDir::new().unwrap();
+    let dest = assert_fs::TempDir::new().unwrap();
+    let origin_dir = Utf8Path::from_path(origin.path()).unwrap();
+    let dest_dir = Utf8Path::from_path(dest.path()).unwrap().join("result");
+
+    // None means it's just a dir, used to make sure empty dirs get copied
+    let mut files = HashMap::new();
+    files.insert("blah/blargh/README3.md", Some("# axoasset3"));
+    files.insert("blah/README2.md", Some("# axoasset2"));
+    files.insert("blah/README.md", Some("# axoasset"));
+    files.insert("styles.css", Some("@import"));
+    files.insert("blah/blargh/empty_dir", None);
+    files.insert("empty/dirs", None);
+    files.insert("root_empty", None);
+
+    for (file, contents) in &files {
+        let asset = origin.child(file);
+        if let Some(contents) = contents {
+            std::fs::create_dir_all(asset.parent().unwrap()).unwrap();
+            asset.write_str(contents).unwrap();
+        } else {
+            asset.create_dir_all().unwrap();
+        }
+    }
+
+    axoasset::LocalAsset::copy_dir_named(origin_dir, &dest_dir).unwrap();
+
+    for (file, contents) in &files {
+        let copied_file = dest_dir.join(file);
+
+        assert!(copied_file.exists());
+        if let Some(contents) = contents {
+            let loaded_asset = axoasset::LocalAsset::load(copied_file).unwrap();
+            assert!(std::str::from_utf8(&loaded_asset.contents)
                 .unwrap()
                 .contains(contents));
         }


### PR DESCRIPTION
* copy_named allows you to specify a name for the dest file
* copy_dir is like copy but for dirs
* copy_dir_named is both put together

These APIs are desired for cargo-dist