### PR TITLE
fix: oranda.json

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -1,3 +1,5 @@
 {
-  "path_prefix": "axoasset"
+  "build": {
+    "path_prefix": "axoasset"
+  }
 }


### PR DESCRIPTION
The syntax has changed since the last time this was changed.

Should fix this error on the most recent push: https://github.com/axodotdev/axoasset/actions/runs/5801175747/job/15724847546