### PR TITLE
chore(deps): remove image decoders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ compression-tar = ["flate2", "tar", "xz2"]
 compression-zip = ["zip"]
 
 [dependencies]
-image = "0.24.5"
+image = { version = "0.24.5", default-features = false }
 mime = "0.3.16"
 reqwest = { version = "0.11.13", optional = true, default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "1.0.37"


### PR DESCRIPTION
We only use MIME type-based detection; we never decode or encode images. Removing the default features from the images crate reduces its dependency tree substantially, cutting out a number of things we never actually use.

I checked, and this eliminates 29 dependencies that are never used by this crate or our projects that use it.