### PR TITLE
feat: use xz2 static feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.159", optional = true, features = ["derive"] }
 tar = { version = "0.4.38", optional = true }
 zip = { version = "0.6.4", optional = true }
 flate2 = { version = "1.0.25", optional = true }
-xz2 = { version = "0.1.7", optional = true }
+xz2 = { version = "0.1.7", optional = true, features = ["static"] }
 toml_edit = { version = "0.21.0", optional = true }
 walkdir = "2.3.3"
 


### PR DESCRIPTION
This ensures that liblzma won't be dynamically linked against.