### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.7.0 - 2024-02-15
+
+Updates dependencies, including a breaking upgrade to miette. Users of this crate will need to update to at least miette 6.0.0.
+
 ### v0.6.2 - 2024-01-23
 
 Fixes zstd compression to actually use zstd, whoops!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axoasset"
 description = ">o_o<"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/axodotdev/axoasset"


### PR DESCRIPTION
We need to get miette 7.0.0 in all our crates to be able to upgrade downstream projects like cargo-dist, so I decided to cut a new release here.