### PR TITLE
fix: parse JSON with UTF-8 BOMs

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -7,6 +7,7 @@ use miette::{MietteSpanContents, SourceCode, SourceSpan};
 use crate::{error::*, LocalAsset};
 
 #[cfg(feature = "toml-edit")]
+#[allow(deprecated)]
 use crate::toml_edit::Document;
 
 #[cfg(feature = "json-serde")]
@@ -127,7 +128,9 @@ impl SourceFile {
 
     /// Try to deserialize the contents of the SourceFile as a toml_edit Document
     #[cfg(feature = "toml-edit")]
+    #[allow(deprecated)]
     pub fn deserialize_toml_edit(&self) -> Result<Document> {
+        #[allow(deprecated)]
         let toml = self.contents().parse::<Document>().map_err(|details| {
             let span = details.span().map(SourceSpan::from);
             AxoassetError::TomlEdit {

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -56,6 +56,31 @@ fn json_valid() {
 
 #[cfg(feature = "json-serde")]
 #[test]
+fn json_with_bom() {
+    #[derive(serde::Deserialize, PartialEq, Eq, Debug)]
+    struct MyType {
+        hello: String,
+        goodbye: bool,
+    }
+
+    // Make the file
+    let contents =
+        String::from("\u{FEFF}") + &String::from(r##"{ "hello": "there", "goodbye": true }"##);
+    let source = axoasset::SourceFile::new("file.js", contents);
+
+    // Get the span for a non-substring (string literal isn't pointing into the String)
+    let val = source.deserialize_json::<MyType>().unwrap();
+    assert_eq!(
+        val,
+        MyType {
+            hello: "there".to_string(),
+            goodbye: true
+        }
+    );
+}
+
+#[cfg(feature = "json-serde")]
+#[test]
 fn json_invalid() {
     use axoasset::AxoassetError;
 
@@ -121,7 +146,7 @@ fn toml_invalid() {
     let contents = String::from(
         r##"
 hello = "there"
-goodbye = 
+goodbye =
 "##,
     );
     let source = axoasset::SourceFile::new("file.toml", contents);
@@ -161,7 +186,7 @@ fn toml_edit_invalid() {
     let contents = String::from(
         r##"
 hello = "there"
-goodbye = 
+goodbye =
 "##,
     );
     let source = axoasset::SourceFile::new("file.toml", contents);


### PR DESCRIPTION
While many JSON parsers can read UTF-8 data that begins with a byte order mark, json-serde can't. This caused an error for us when reading data that originated from PowerShell on Windows, which always writes a byte order mark at the beginning of the file even when using UTF-8.

I've added a test for this and confirmed the new test fails without the new changes.

See: https://github.com/serde-rs/json/issues/1115