### PR TITLE
chore: make image optional, use in remote

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ default = ["remote"]
 toml-serde = ["toml", "serde"]
 json-serde = ["serde_json", "serde"]
 toml-edit = ["toml_edit"]
-remote = ["reqwest"]
+remote = ["reqwest", "image"]
 compression = ["compression-tar", "compression-zip"]
 compression-tar = ["flate2", "tar", "xz2", "zstd"]
 compression-zip = ["zip"]
 
 [dependencies]
-image = { version = "0.25.1", default-features = false }
+image = { version = "0.25.1", default-features = false, optional = true }
 mime = "0.3.16"
 reqwest = { version = "0.11.13", optional = true, default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "1.0.37"

--- a/tests/local_write.rs
+++ b/tests/local_write.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "image")]
 #![allow(irrefutable_let_patterns)]
 
 use std::collections::HashMap;


### PR DESCRIPTION
Historically this has had one of our heavier dependency trees, though it's currently down to about 6 crates and ~30-40KB in the final binary. That's still not nothing, and since it's only used in the `remote` feature, we can easily scope it to only be used there.