### PR TITLE
chore: relax reqwest version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ compression-zip = ["zip"]
 [dependencies]
 image = { version = "0.25.1", default-features = false, optional = true }
 mime = "0.3.16"
-reqwest = { version = "0.12.4", optional = true, default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = ">=0.11.0", optional = true, default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "1.0.37"
 url = "2.5.0"
 miette = "7.0.0"


### PR DESCRIPTION
This makes it easier for apps using more than one library that uses reqwest to ensure all are using the same version.