### PR TITLE
fix: better handle extensions for unrecognized mimetypes

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -113,14 +113,11 @@ impl RemoteAsset {
         }
     }
 
-    fn extension(mimetype: mime::Mime, origin_path: &str) -> Result<String> {
+    fn extension(mimetype: mime::Mime, origin_path: &str) -> Option<String> {
         match mimetype.type_() {
-            mime::IMAGE => RemoteAsset::image_extension(mimetype, origin_path),
-            mime::TEXT => RemoteAsset::text_extension(mimetype, origin_path),
-            _ => Err(AxoassetError::RemoteAssetMimeTypeNotSupported {
-                origin_path: origin_path.to_string(),
-                mimetype: mimetype.to_string(),
-            }),
+            mime::IMAGE => RemoteAsset::image_extension(mimetype, origin_path).ok(),
+            mime::TEXT => RemoteAsset::text_extension(mimetype, origin_path).ok(),
+            _ => None,
         }
     }
 
@@ -179,10 +176,12 @@ impl RemoteAsset {
         filestem.remove(0);
         if filestem.contains('.') {
             Ok(filestem)
-        } else {
-            let extension =
-                RemoteAsset::extension(RemoteAsset::mimetype(headers, origin_path)?, origin_path)?;
+        } else if let Some(extension) =
+            RemoteAsset::extension(RemoteAsset::mimetype(headers, origin_path)?, origin_path)
+        {
             Ok(format!("{filestem}.{extension}"))
+        } else {
+            Ok(filestem)
         }
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -176,10 +176,12 @@ impl RemoteAsset {
         filestem.remove(0);
         if filestem.contains('.') {
             Ok(filestem)
-        } else if let Some(extension) =
-            RemoteAsset::extension(RemoteAsset::mimetype(headers, origin_path)?, origin_path)
-        {
-            Ok(format!("{filestem}.{extension}"))
+        } else if let Ok(mimetype) = RemoteAsset::mimetype(headers, origin_path) {
+            if let Some(extension) = RemoteAsset::extension(mimetype, origin_path) {
+                Ok(format!("{filestem}.{extension}"))
+            } else {
+                Ok(filestem)
+            }
         } else {
             Ok(filestem)
         }


### PR DESCRIPTION
Previously we'd error out if we couldn't decide on a filename for the file. Now, if we don't assign an extension based on the mimetype, we'll simply return the original filename unmodified.

cf these custom versions of `RemoteAsset::copy` - we'll want to make sure this does what we want before merging. https://github.com/axodotdev/cargo-dist/blob/66b5ffaaee88a375c69f1c655ac26b0261cb20f3/cargo-dist/src/sign/ssldotcom.rs#L203