### PR TITLE
chore: loosen dependency ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,22 @@ compression-tar = ["flate2", "tar", "xz2", "zstd"]
 compression-zip = ["zip"]
 
 [dependencies]
-image = { version = "0.25.1", default-features = false, optional = true }
-mime = "0.3.16"
+image = { version = ">=0.25.1", default-features = false, optional = true }
+mime = ">=0.3.16"
 reqwest = { version = ">=0.11.0", optional = true, default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "1.0.37"
 url = "2.5.0"
 miette = "7.0.0"
 camino = "1.1.4"
-toml = { version = "0.8.12", optional = true }
+toml = { version = ">= 0.8.12", optional = true }
 serde_json = { version = "1.0.117", optional = true }
 serde = { version = "1.0.202", optional = true, features = ["derive"] }
-tar = { version = "0.4.40", optional = true }
-zip = { version = "0.6.4", optional = true }
+tar = { version = ">= 0.4.40", optional = true }
+zip = { version = ">= 0.6.4", optional = true }
 flate2 = { version = "1.0.30", optional = true }
-xz2 = { version = "0.1.7", optional = true, features = ["static"] }
-zstd = { version = "0.13.0", optional = true }
-toml_edit = { version = "0.22.5", optional = true }
+xz2 = { version = ">= 0.1.7", optional = true, features = ["static"] }
+zstd = { version = ">= 0.13.0", optional = true }
+toml_edit = { version = ">= 0.22.5", optional = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Similar to the changes made in #125. I left the 1.x.x dependencies alone since the ranges on those are wider and more like what we expect:

https://doc.rust-lang.org/stable/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio