### PR TITLE
chore: set dependabot strategy to increase-if-necessary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: daily
       time: "10:00"
     open-pull-requests-limit: 10
+    versioning-strategy: widen


### PR DESCRIPTION
This will keep it from bumping the lower range of dependencies in Cargo.toml, which would require any users of axoasset to update to the same version.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy