### PR TITLE
fix: move pub use reqwest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@ use error::Result;
 pub use local::LocalAsset;
 #[cfg(feature = "remote")]
 pub use remote::RemoteAsset;
+// Simplifies raw access to reqwest without depending on a separate copy
+#[cfg(feature = "remote")]
+pub use reqwest;
 #[cfg(feature = "json-serde")]
 pub use serde_json;
 pub use source::SourceFile;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -3,9 +3,6 @@ use std::path::{Path, PathBuf};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
-// Simplifies raw access to reqwest without depending on a separate copy
-pub use reqwest;
-
 use crate::error::*;
 
 /// A remote asset is an asset that is fetched over the network.


### PR DESCRIPTION
This was placed in the `remote` module, which isn't actually exposed to external users. It needs to be `pub use`d from `lib` if it's going to be accessible.