### PR TITLE
fix: relax serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ url = "2.5.0"
 miette = "7.0.0"
 camino = "1.1.4"
 toml = { version = "0.8.12", optional = true }
-serde_json = { version = "1.0.117", optional = true }
+serde_json = { version = "1.0.95", optional = true }
 serde = { version = "1.0.202", optional = true, features = ["derive"] }
 tar = { version = "0.4.40", optional = true }
 zip = { version = "0.6.4", optional = true }


### PR DESCRIPTION
This was bumped in 9d02db2624c5344e6176b5e8960e6eeb4522410e, before we started being careful with the version changes in Cargo.toml.