### PR TITLE
Allow overriding compression levels with environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "clap",
  "flate2",
  "image",
+ "lazy_static",
  "miette",
  "mime",
  "reqwest",
@@ -908,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ xz2 = { version = "0.1.7", optional = true, features = ["static"] }
 zstd = { version = "0.13.0", optional = true }
 toml_edit = { version = "0.22.5", optional = true }
 walkdir = "2.5.0"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 assert_fs = "1"


### PR DESCRIPTION
This introduces three environment variables, with the following defaults:

  * `AXOASSET_GZ_LEVEL=6`
  * `AXOASSET_XZ_LEVEL=9`
  * `AXOASSET_ZSTD_LEVEL=3`

(The defaults are unchanged, but when we iterate on dist builds using dist itself, exporting `AXOASSET_XZ_LEVEL=1` will make it go faster — it is _genuinely_ the blocker on warm builds lol)