### PR TITLE
fix: preserve Unix permissions in ZIPs

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -3,6 +3,9 @@
 use camino::Utf8Path;
 #[cfg(feature = "compression-zip")]
 use camino::Utf8PathBuf;
+#[cfg(feature = "compression-zip")]
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use crate::AxoassetError;
 
@@ -352,6 +355,11 @@ pub(crate) fn zip_dir_impl(
         // Write file or directory explicitly
         // Some unzip tools unzip files with directory paths correctly, some do not!
         if path.is_file() {
+            // On Unix, we want to make sure we preserve permissions
+            // (like the execute bit!) from the source file
+            #[cfg(unix)]
+            let options = options.unix_permissions(path.metadata()?.permissions().mode());
+
             zip.start_file(&unix_name, options)?;
             let mut f = File::open(path)?;
 


### PR DESCRIPTION
We weren't setting the `unix_permissions` parameter on the options object to ensure that the compressed files get the same permissions as the source files.

Fixes axodotdev/cargo-dist#3032.

cc @jackTabsCode 